### PR TITLE
Fix: Escape HTML special charaters in SpanWithHyperlink component #59

### DIFF
--- a/app/component/textWithHyperlink.jsx
+++ b/app/component/textWithHyperlink.jsx
@@ -1,12 +1,23 @@
+export default function SpanWithHyperlink({ line }) {
+  // HTML 특수 문자를 이스케이프 처리
+  const escapeHTML = (text) => {
+    return text.replace(/&/g, "&amp;")
+               .replace(/</g, "&lt;")
+               .replace(/>/g, "&gt;")
+               .replace(/"/g, "&quot;")
+               .replace(/'/g, "&#039;");
+  };
 
-export default function spanWithHyperlink({line}) {
+  // URL을 하이퍼링크로 변환
   const urlPattern = /(http|https):\/\/([\w-]+(\.[\w-]+)+)(\/[\w-./?%&=]*)?$/g;
-  const converter = (text) => text.replace(urlPattern, (url) => {
+  const converter = (text) => escapeHTML(text).replace(urlPattern, (url) => {
     return `<a style="text-decoration:underline;" href="${url}" target="_blank">${url}</a>`;
-  })
+  });
+
+
   return (
     <span>
-      <span dangerouslySetInnerHTML={{__html: [converter(line)]}}/>
+      <span dangerouslySetInnerHTML={{ __html: converter(line) }} />
       <br />
     </span>
   );


### PR DESCRIPTION
# ⚠️ 연관된 이슈

> close #59 

# 🔨 작업 내용

> 도메인: 관련 URL(Frontend), API 주소(BackEnd), Schema 등

### 도메인:  `/components/SpanWithHyperlink.jsx`
- `SpanWithHyperlink` 컴포넌트에서 HTML 특수 문자를 안전하게 처리하도록 변경
- `dangerouslySetInnerHTML` 사용 시, HTML 태그가 텍스트로 변환되지 않도록 수정 
- URL 링크를 자동으로 감지하고 하이퍼링크로 변환하도록 변경
