### PR TITLE
Enhancement: Implement URL parameter handling #62

### DIFF
--- a/app/component/textWithHyperlink.jsx
+++ b/app/component/textWithHyperlink.jsx
@@ -1,12 +1,23 @@
+export default function SpanWithHyperlink({ line }) {
+  // HTML 특수 문자를 이스케이프 처리
+  const escapeHTML = (text) => {
+    return text.replace(/&/g, "&amp;")
+               .replace(/</g, "&lt;")
+               .replace(/>/g, "&gt;")
+               .replace(/"/g, "&quot;")
+               .replace(/'/g, "&#039;");
+  };
 
-export default function spanWithHyperlink({line}) {
+  // URL을 하이퍼링크로 변환
   const urlPattern = /(http|https):\/\/([\w-]+(\.[\w-]+)+)(\/[\w-./?%&=]*)?$/g;
-  const converter = (text) => text.replace(urlPattern, (url) => {
+  const converter = (text) => escapeHTML(text).replace(urlPattern, (url) => {
     return `<a style="text-decoration:underline;" href="${url}" target="_blank">${url}</a>`;
-  })
+  });
+
+
   return (
     <span>
-      <span dangerouslySetInnerHTML={{__html: [converter(line)]}}/>
+      <span dangerouslySetInnerHTML={{ __html: converter(line) }} />
       <br />
     </span>
   );

--- a/app/find/page.js
+++ b/app/find/page.js
@@ -44,6 +44,11 @@ export default function find() {
     urlParams.append("reverse", reverse);
     urlParams.append("isRecruiting", isRecruiting);
 
+    // URL 동적으로 업데이트 
+    const newURL = `${window.location.pathname}?${urlParams.toString()}`; 
+    window.history.pushState({ path: newURL }, '', newURL); 
+    // 검색 버튼 클릭 -> URL 변경 
+
     const rows = await fetch('/api/clubs?' + urlParams.toString(), {
       method: "GET"
     });
@@ -77,6 +82,50 @@ export default function find() {
     }
     else isMounted.current = true;
   }, [SortSelected, CollegeSelected, reverse, isRecruiting])
+
+  // 페이지 로드 -> URL 파라미터 추출하여 상태 결정
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+
+    const searchQuery = urlParams.get('search') || '';
+    const tagQuery = urlParams.get('tag') || '';
+    const sortByQuery = urlParams.get('sortBy') || 'popularity';
+    const pageQuery = parseInt(urlParams.get('page')) || 1;
+    const reverseQuery = parseInt(urlParams.get('reverse')) || 0;
+    const isRecruitingQuery = parseInt(urlParams.get('isRecruiting')) || 0;
+
+    document.getElementById('search_').value = searchQuery;
+    document.getElementById('tag_').value = tagQuery;
+
+    setSortSelected(sortByQuery);
+    setPage(pageQuery);
+    setReverse(reverseQuery);
+    setIsRecruiting(isRecruitingQuery);
+
+    GetClubs();
+
+    // 뒤로가기/ 앞으로가기 시 상태 유지 
+    window.onpopstate = () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      
+      const searchQuery = urlParams.get('search') || '';
+      const tagQuery = urlParams.get('tag') || '';
+      const sortByQuery = urlParams.get('sortBy') || 'popularity';
+      const pageQuery = parseInt(urlParams.get('page')) || 1;
+      const reverseQuery = parseInt(urlParams.get('reverse')) || 0;
+      const isRecruitingQuery = parseInt(urlParams.get('isRecruiting')) || 0;
+
+      document.getElementById('search_').value = searchQuery;
+      document.getElementById('tag_').value = tagQuery;
+
+      setSortSelected(sortByQuery);
+      setPage(pageQuery);
+      setReverse(reverseQuery);
+      setIsRecruiting(isRecruitingQuery);
+
+      GetClubs();
+    };
+  }, []);
 
   return (
     <div className={Styles.Container}>


### PR DESCRIPTION
# ⚠️ 연관된 이슈


close #62

# 🔨 작업 내용

### 도메인: `/find` 페이지 관련 URL 파라미터 처리
- URL 파라미터로 검색, 태그, 정렬 필터를 동적으로 업데이트 
- 컴포넌트 마운트 -> URL 파라미터를 파싱 (상태를 초기화) / 뒤로가기, 앞으로 가기 동작에 대응 

# 🖼️ 참고 이미지 및 영상


# 💬 추가 사항

